### PR TITLE
Ask Google not to translate website

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#ffc107">
 
-
+    <meta name="google" content="notranslate">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-title" content="EteSync">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">


### PR DESCRIPTION
Ask Google to not analyse the contents of the page for translation purposes

Google may analyse sensitive content for the purpose of recognising whether the page needs to be translated, see https://support.google.com/webmasters/answer/79812?hl=en

(as it has reportedly been happened with Protonmail)

----

Hello dear user. Consider switching to Firefox. We can only ask Google's browser to not do it. We cannot prevent it...

---

adopted/credits from/to https://github.com/threema-ch/threema-web/pull/681 by @lgrahl (I hope the plain copy is okay :smile:)