### PR TITLE
Clicking a task goes directly to edit page

### DIFF
--- a/src/Pim/PimMain.tsx
+++ b/src/Pim/PimMain.tsx
@@ -64,7 +64,7 @@ class PimMain extends React.PureComponent<PropsType> {
     const itemUid = `${(event as any).journalUid}|${event.uid}`;
 
     this.props.history!.push(
-      routeResolver.getRoute('pim.tasks._id', { itemUid }));
+      routeResolver.getRoute('pim.tasks._id.edit', { itemUid }));
   }
 
   public contactClicked(contact: ContactType) {


### PR DESCRIPTION
Changes the user flow so that selecting a task bypasses the "Task view" and goes directly to the edit page.