### PR TITLE
RRule: handle undefined options.byday

### DIFF
--- a/src/widgets/RRule.tsx
+++ b/src/widgets/RRule.tsx
@@ -176,7 +176,7 @@ export default function RRule(props: PropsType) {
           <FormControl>
             <InputLabel>Weekdays</InputLabel>
             <Select
-              value={sanitizeByDay(options.byday)}
+              value={sanitizeByDay(options.byday) ?? []}
               multiple
               style={styles.multiSelect}
               onChange={(event: React.ChangeEvent<{ value: unknown }>) => {

--- a/src/widgets/RRule.tsx
+++ b/src/widgets/RRule.tsx
@@ -103,7 +103,7 @@ function sanitizeByDay(item: string | string[] | undefined) {
       return value;
     });
   } else {
-    return ret;
+    return [];
   }
 }
 
@@ -176,7 +176,7 @@ export default function RRule(props: PropsType) {
           <FormControl>
             <InputLabel>Weekdays</InputLabel>
             <Select
-              value={sanitizeByDay(options.byday) ?? []}
+              value={sanitizeByDay(options.byday)}
               multiple
               style={styles.multiSelect}
               onChange={(event: React.ChangeEvent<{ value: unknown }>) => {


### PR DESCRIPTION
RRule previously caused a crash on mount because `options.byday` is initially undefined.
`Select` component with prop `multiple` requires `value` to be an array.