### PR TITLE
Task edit: fix incorrectly stored DateTimes

### DIFF
--- a/src/components/Tasks/TaskEdit.tsx
+++ b/src/components/Tasks/TaskEdit.tsx
@@ -173,7 +173,7 @@ class TaskEdit extends React.PureComponent<PropsType> {
         return ret;
       } else {
         const data = ret.toJSON();
-        data.isDate = false;
+        data.isDate = true;
         return ICAL.Time.fromData(data);
       }
     }


### PR DESCRIPTION
I messed up a boolean value with my previous pull request. It was causing DateTimes to be stored as Dates and vice-versa.