### PR TITLE
Tasks: fix priority sorting

### DIFF
--- a/src/components/Tasks/TaskList.tsx
+++ b/src/components/Tasks/TaskList.tsx
@@ -41,9 +41,9 @@ function sortDueDate(aIn: TaskType, bIn: TaskType) {
 }
 
 function sortPriority(aIn: TaskType, bIn: TaskType) {
-  // Intentionally converts 0/undefined to Infinity to sort to back of the list
-  const a = aIn.priority || Infinity;
-  const b = bIn.priority || Infinity;
+  // Intentionally converts 0/undefined to 10 (1 more than lowest priority) to sort to back of the list
+  const a = aIn.priority || 10;
+  const b = bIn.priority || 10;
   return a - b;
 }
 
@@ -67,6 +67,7 @@ function getSortFunction(sortOrder: string) {
       break;
     case 'priority':
       sortFunctions.push(sortPriority);
+      sortFunctions.push(sortDueDate);
       break;
     case 'title':
       sortFunctions.push(sortTitle);


### PR DESCRIPTION
Priority sorting had some inconsistencies. 
The Infinity was causing tasks to not be sorted (Infinity - Infinity = NaN).
Adding sortByDueDate also ensures better sorting when tasks have the same priority