### PR TITLE
Fix autoRefresh interrupting editing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -282,7 +282,11 @@ class App extends React.PureComponent {
   }
 
   private autoRefresh() {
-    if (navigator.onLine && this.props.credentials) { this.refresh() }
+    if (navigator.onLine && this.props.credentials &&
+      !(window.location.pathname.match(/.*\/(new|edit|copy)$/))) { 
+      this.refresh();
+    }
+
   }
 
   componentDidMount() {


### PR DESCRIPTION
The autoRefresh function now checks the end of the URL to prevent refreshing when the user is editing an item. 

Fixes #145 