### PR TITLE
Hide birthday collection when creating new events

### DIFF
--- a/src/Pim/index.tsx
+++ b/src/Pim/index.tsx
@@ -60,13 +60,19 @@ const itemsSelector = createSelector(
 
         if (collectionInfo.type === "ADDRESS_BOOK") {
           addressBookItems = syncEntriesToItemMap(collectionInfo, syncEntries, addressBookItems);
-          collectionsAddressBook.push(collectionInfo);
+          if (!syncJournal.journal.readOnly) {
+            collectionsAddressBook.push(collectionInfo);
+          }
         } else if (collectionInfo.type === "CALENDAR") {
           calendarItems = syncEntriesToEventItemMap(collectionInfo, syncEntries, calendarItems);
-          collectionsCalendar.push(collectionInfo);
+          if (!syncJournal.journal.readOnly) {
+            collectionsCalendar.push(collectionInfo);
+          }
         } else if (collectionInfo.type === "TASKS") {
           taskListItems = syncEntriesToTaskItemMap(collectionInfo, syncEntries, taskListItems);
-          collectionsTaskList.push(collectionInfo);
+          if (!syncJournal.journal.readOnly) {
+            collectionsTaskList.push(collectionInfo);
+          }
         }
       }
     );

--- a/src/components/EventEdit.tsx
+++ b/src/components/EventEdit.tsx
@@ -300,7 +300,7 @@ class EventEdit extends React.PureComponent<PropsType> {
             <Select
               name="journalUid"
               value={this.state.journalUid}
-              disabled={this.props.item !== undefined}
+              disabled={this.props.item !== undefined && !this.props.duplicate}
               onChange={this.handleInputChange}
             >
               {this.props.collections.map((x) => (


### PR DESCRIPTION
Currently you can choose the birthday collection when creating a new event, which  leads to an error.

Also, I noticed that switching calendars is disabled when duplicating an event, so I fixed that too.