### PR TITLE
Fix localization for DateTimePicker

### DIFF
--- a/src/widgets/DateTimePicker.tsx
+++ b/src/widgets/DateTimePicker.tsx
@@ -23,7 +23,7 @@ class DateTimePicker extends React.PureComponent<PropsType> {
 
   public render() {
     const Picker = (this.props.dateOnly) ? KeyboardDatePicker : KeyboardDateTimePicker;
-    const dateFormat = (this.props.dateOnly) ? "DD/MM/YYYY" : "DD/MM/YYYY HH:mm";
+    const dateFormat = (this.props.dateOnly) ? "L" : "L LT";
     return (
       <MuiPickersUtilsProvider utils={MomentUtils}>
         <Picker


### PR DESCRIPTION
Use date format based on the locale setting for adding/editing a calendar event instead of hardcoding it.

Tested by making sure the observed format was "DD/MM/YYYY" when the locale is English (United Kingdom) and "MM/DD/YYYY" when the locale is English (United States).