### PR TITLE
Add Docker Build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+# Builds the Web Client from the latest git repo
+
+# Build Stage =====================================================================================
+FROM node:alpine as build
+ENV DEFAULT_ETEBASE_SERVER "http://example.com"
+RUN export REACT_APP_DEFAULT_API_PATH=${DEFAULT_ETEBASE_SERVER} && \
+    git clone https://github.com/etesync/etesync-web.git etesync-web && \
+    cd etesync-web && \
+    yarn && \
+    yarn build
+
+# Run Stage =======================================================================================
+FROM nginx:alpine
+COPY --from=build /etesync-web/build /usr/share/nginx/html
+COPY ./nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+EOF

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,17 @@
+server {
+
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    charset utf-8;
+    client_max_body_size 75M;     # max upload size
+    location /        {
+      root /usr/share/nginx/html;
+      try_files $uri $uri/ /index.html =404;
+      autoindex on;
+    }
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}
+EOF


### PR DESCRIPTION
This should reopen the pull request to add the docker build. 

I understand that you are reluctant to take on the packaging for docker as the web client is nothing more than a bundle of static files. But this docker is very simple, All it does is pull the latest version of the web client from git and build it in a node docker container, then copies the built files from that build container into an official nginx container. It will require little to no maintenace. 

In addition, seeing as there are docker images for both the server and the dav bridge, it would make logical sense to have one as well for the web client. This would fulfill that role. 

I am willing to take on maintenance for any bug reports or feature requests for the docker package. All you have to do is assign the relevant issues to me. 

I just really wish to see an official web client image that users can use and trust. The dockerfile would be in the codebase for all to see and verify for themselves and it would simplify installation and self hosting.