### PR TITLE
Improve PWA manifest

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,7 +8,7 @@
       "type": "image/png"
     }
   ],
-  "start_url": "./index.html",
+  "start_url": "https://pim.etesync.com/",
   "display": "standalone",
   "theme_color": "#ffc107",
   "background_color": "#03a9f4"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,7 @@
 {
   "short_name": "EteSync",
   "name": "EteSync - Secure Data Sync",
+  "description": "Secure, end-to-end encrypted, and privacy respecting sync for your contacts, calendars, tasks, and notes.",
   "icons": [
     {
       "src": "favicon.ico",
@@ -8,8 +9,38 @@
       "type": "image/png"
     }
   ],
-  "start_url": "https://pim.etesync.com/",
+  "start_url": "https://pim.etesync.com",
   "display": "standalone",
   "theme_color": "#ffc107",
-  "background_color": "#03a9f4"
+  "background_color": "#03a9f4",
+  "categories": [
+    "productivity",
+    "utilities"
+  ],
+  "related_applications": [
+    {
+      "platform": "play",
+      "url": "https://play.google.com/store/apps/details?id=com.etesync.syncadapter",
+      "id": "com.etesync.syncadapter"
+    }, {
+      "platform": "itunes",
+      "url": "https://apps.apple.com/us/app/apple-store/id1489574285"
+    }, {
+      "platform": "f-droid",
+      "url": "https://f-droid.org/packages/com.etesync.syncadapter/",
+      "id": "com.etesync.syncadapter"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "Calendar",
+      "url": "/pim/events"
+    }, {
+      "name": "Tasks",
+      "url": "/pim/tasks"
+    }, {
+      "name": "Address Book",
+      "url": "/pim/contacts"
+    }
+  ]
 }


### PR DESCRIPTION
This started when installing the PWA directed me to index.html, which gave me a 404 error. I decided to fix that, and while I was at it, I figured I might as well add a few more fields to the manifest!

All of the specs added were added as documented in https://developer.mozilla.org/en-US/docs/Web/Manifest.

The only improvement I can see to add would be [screenshots](https://developer.mozilla.org/en-US/docs/Web/Manifest/screenshots), but as my calendar, tasks, etc. are filled with my personal info, I'd prefer not to upload my own screenshots :-). Is there any way you could generate some screenshots on a dummy account and host them on your website, Github, or IPFS so that they can be pulled in by the manifest?