### PR TITLE
fix event descriptions to respect whitespace

### DIFF
--- a/src/Calendars/Event.tsx
+++ b/src/Calendars/Event.tsx
@@ -35,7 +35,7 @@ class Event extends React.PureComponent {
           <div><u>{this.props.item.location}</u></div>
         </PimItemHeader>
         <div style={style.content}>
-          <p style={{ wordWrap: "break-word" }}>{this.props.item.description}</p>
+          <p style={{ wordWrap: "break-word", whiteSpace: "pre-wrap" }}>{this.props.item.description}</p>
           {(this.props.item.attendees.length > 0) && (
             <div>Attendees: {this.props.item.attendees.map((x) => (x.getFirstValue())).join(", ")}</div>)}
         </div>


### PR DESCRIPTION
I haven't actually stood up a local server yet to test this, but thought I'd hit send anyway. LMK if looks good and then I'll figure out how to test locally (just... in the wildly-off-chance somehow I caused a react bug or something)