### PR TITLE
Improve Layout of ContactEdit

### DIFF
--- a/src/Contacts/ContactEdit.tsx
+++ b/src/Contacts/ContactEdit.tsx
@@ -95,7 +95,7 @@ interface ValueTypeComponentProps {
 
   types: Array<{ type: string }>;
   name: string;
-  placeholder: string;
+  label: string;
   value: ValueType;
   onClearRequest: (name: string) => void;
   onChange: (name: string, type: string, value: string) => void;
@@ -108,7 +108,7 @@ const ValueTypeComponent = (props: ValueTypeComponentProps) => {
         <Grid item xs>
           <TextField
             type={props.type}
-            label={props.placeholder}
+            label={props.label}
             multiline={props.multiline}
             variant="outlined"
             style={props.style}
@@ -614,7 +614,7 @@ class ContactEdit extends React.PureComponent<PropsType> {
                     <ValueTypeComponent
                       key={idx}
                       name="phone"
-                      placeholder="Phone"
+                      label="Phone"
                       types={telTypes}
                       typeLabel="Label"
                       value={x}
@@ -678,7 +678,7 @@ class ContactEdit extends React.PureComponent<PropsType> {
                     <ValueTypeComponent
                       key={idx}
                       name="email"
-                      placeholder="Email"
+                      label="Email"
                       types={emailTypes}
                       style={{ ...styles.fullWidth }}
                       value={x}
@@ -711,7 +711,7 @@ class ContactEdit extends React.PureComponent<PropsType> {
                     <ValueTypeComponent
                       key={idx}
                       name="impp"
-                      placeholder="IMPP"
+                      label="IMPP"
                       types={imppTypes}
                       style={{ ...styles.fullWidth }}
                       value={x}
@@ -744,7 +744,7 @@ class ContactEdit extends React.PureComponent<PropsType> {
                     <ValueTypeComponent
                       key={idx}
                       name="address"
-                      placeholder="Address"
+                      label="Address"
                       types={addressTypes}
                       style={{ ...styles.fullWidth }}
                       multiline

--- a/src/Contacts/ContactEdit.tsx
+++ b/src/Contacts/ContactEdit.tsx
@@ -8,13 +8,13 @@ import TextField from "@material-ui/core/TextField";
 import Select from "@material-ui/core/Select";
 import MenuItem from "@material-ui/core/MenuItem";
 import FormControl from "@material-ui/core/FormControl";
-import InputLabel from "@material-ui/core/InputLabel";
 import * as colors from "@material-ui/core/colors";
 
 import IconDelete from "@material-ui/icons/Delete";
 import IconClear from "@material-ui/icons/Clear";
 import IconCancel from "@material-ui/icons/Clear";
 import IconSave from "@material-ui/icons/Save";
+import IconSaveTo from "@material-ui/icons/FolderOutlined";
 import IconPerson from "@material-ui/icons/PersonOutlined";
 import IconOrganization from "@material-ui/icons/BusinessOutlined";
 import IconPhone from "@material-ui/icons/PhoneOutlined";
@@ -494,22 +494,31 @@ class ContactEdit extends React.PureComponent<PropsType> {
           {this.props.item ? "Edit Contact" : "New Contact"}
         </h2>
         <form style={styles.form} onSubmit={this.onSubmit}>
-          <FormControl disabled={this.props.item !== undefined} style={styles.fullWidth}>
-            <InputLabel>
-              Saving to
-            </InputLabel>
-            <Select
-              name="collectionUid"
-              value={this.state.collectionUid}
-              onChange={this.handleCollectionChange}
-            >
-              {this.props.collections.map((x) => (
-                <MenuItem key={x.collection.uid} value={x.collection.uid}>{x.metadata.name}</MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-
           <Grid container direction="column" spacing={4} style={{ marginTop: "1.5rem", marginBottom: "1.5rem", paddingLeft: "0.5rem", paddingRight: "1rem" }}>
+            <Grid container item direction="row" spacing={2}>
+              <Grid item xs="auto">
+                <IconSaveTo style={{ paddingTop: "1rem" }} />
+              </Grid>
+
+              <Grid item>
+                <FormControl
+                  disabled={this.props.item !== undefined}
+                  style={styles.fullWidth}
+                >
+                  <Select
+                    name="collectionUid"
+                    value={this.state.collectionUid}
+                    variant="outlined"
+                    onChange={this.handleCollectionChange}
+                  >
+                    {this.props.collections.map((x) => (
+                      <MenuItem key={x.collection.uid} value={x.collection.uid}>{x.metadata.name}</MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Grid>
+            </Grid>
+
             <Grid container item direction="row" spacing={2}>
               <Grid item xs="auto">
                 <IconPerson style={{ paddingTop: "1rem" }} />

--- a/src/Contacts/ContactEdit.tsx
+++ b/src/Contacts/ContactEdit.tsx
@@ -496,354 +496,356 @@ class ContactEdit extends React.PureComponent<PropsType> {
 
     return (
       <React.Fragment>
-        <h2>
-          {this.props.item ? "Edit Contact" : "New Contact"}
-        </h2>
-        <form style={styles.form} onSubmit={this.onSubmit}>
-          <Grid container direction="column" spacing={4} style={{ marginTop: "1.5rem", marginBottom: "1.5rem", paddingLeft: "0.5rem", paddingRight: "1rem" }}>
-            <Grid container item direction="row" spacing={2}>
-              <Grid item xs="auto">
-                <IconSaveTo style={{ paddingTop: "1rem" }} />
-              </Grid>
-
-              <Grid item xs="auto">
-                <FormControl
-                  disabled={this.props.item !== undefined}
-                  style={styles.fullWidth}
-                >
-                  <Select
-                    name="collectionUid"
-                    value={this.state.collectionUid}
-                    variant="outlined"
-                    onChange={this.handleCollectionChange}
-                  >
-                    {this.props.collections.map((x) => (
-                      <MenuItem key={x.collection.uid} value={x.collection.uid}>{x.metadata.name}</MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-              </Grid>
-            </Grid>
-
-            <Grid container item direction="row" spacing={2}>
-              <Grid item xs="auto">
-                <IconPerson style={{ paddingTop: "1rem" }} />
-              </Grid>
-
-              <Grid container item direction="column" spacing={2} xs>
-                {(this.state.showAllNameFields || this.state.namePrefix) &&
-                  <Grid item>
-                    <TextField
-                      name="namePrefix"
-                      label="Prefix"
-                      variant="outlined"
-                      style={{ ...styles.fullWidth }}
-                      value={this.state.namePrefix}
-                      onChange={this.handleInputChange}
-                    />
-                  </Grid>
-                }
-
-                <Grid item>
-                  <TextField
-                    name="firstName"
-                    label="First name"
-                    variant="outlined"
-                    style={{ ...styles.fullWidth }}
-                    value={this.state.firstName}
-                    onChange={this.handleInputChange}
-                  />
+        <div style={{ paddingLeft: "0.5rem", paddingRight: "1rem" }}>
+          <h2>
+            {this.props.item ? "Edit Contact" : "New Contact"}
+          </h2>
+          <form style={styles.form} onSubmit={this.onSubmit}>
+            <Grid container direction="column" spacing={4} style={{ marginTop: "0.5rem" }}>
+              <Grid container item direction="row" spacing={2}>
+                <Grid item xs="auto">
+                  <IconSaveTo style={{ paddingTop: "1rem" }} />
                 </Grid>
-
-                {(this.state.showAllNameFields || this.state.middleName) &&
-                  <Grid item>
-                    <TextField
-                      name="middleName"
-                      label="Middle name"
-                      variant="outlined"
-                      style={{ ...styles.fullWidth }}
-                      value={this.state.middleName}
-                      onChange={this.handleInputChange}
-                    />
-                  </Grid>
-                }
-
-                <Grid item>
-                  <TextField
-                    name="lastName"
-                    label="Last name"
-                    variant="outlined"
-                    style={{ ...styles.fullWidth }}
-                    value={this.state.lastName}
-                    onChange={this.handleInputChange}
-                  />
-                </Grid>
-
-                {(this.state.showAllNameFields || this.state.nameSuffix) &&
-                  <Grid item>
-                    <TextField
-                      name="nameSuffix"
-                      label="Suffix"
-                      variant="outlined"
-                      style={{ ...styles.fullWidth }}
-                      value={this.state.nameSuffix}
-                      onChange={this.handleInputChange}
-                    />
-                  </Grid>
-                }
-              </Grid>
-
-              <Grid item xs="auto">
-                <IconButton
-                  onClick={() => this.setState({ showAllNameFields: !this.state.showAllNameFields })}
-                  title="Show all name fields"
-                >
-                  {this.state.showAllNameFields ? <IconExpandLess /> : <IconExpandMore />}
-                </IconButton>
-              </Grid>
-            </Grid>
-
-            <Grid container item direction="row" spacing={2}>
-              <Grid item xs="auto">
-                <IconPhone style={{ paddingTop: "1rem" }} />
-              </Grid>
-
-              <Grid container item direction="column" spacing={2} xs>
-                {this.state.phone.map((x, idx) => (
-                  <ValueTypeComponent
-                    key={idx}
-                    name="phone"
-                    placeholder="Phone"
-                    types={telTypes}
-                    typeLabel="Label"
-                    value={x}
-                    style={{ ...styles.fullWidth }}
-                    onClearRequest={(name: string) => this.removeValueType(name, idx)}
-                    onChange={(name: string, type: string, value: string) => (
-                      this.handleValueTypeChange(name, idx, { type, value })
-                    )}
-                  />
-                ))}
 
                 <Grid item xs="auto">
-                  <Button
-                    onClick={() => this.addValueType("phone")}
-                    color="secondary"
-                    variant="outlined"
-                    style={{ height: "3.5rem", fontSize: "1em" }}
-                  >
-                    Add phone number
-                  </Button>
-                </Grid>
-              </Grid>
-            </Grid>
-
-            <Grid container item direction="row" spacing={2}>
-              <Grid item xs="auto">
-                <IconOrganization style={{ paddingTop: "1rem" }} />
-              </Grid>
-
-              <Grid container item direction="column" spacing={2} xs>
-                <Grid item>
-                  <TextField
-                    name="org"
-                    label="Organization"
-                    variant="outlined"
+                  <FormControl
+                    disabled={this.props.item !== undefined}
                     style={styles.fullWidth}
-                    value={this.state.org}
-                    onChange={this.handleInputChange}
-                  />
+                  >
+                    <Select
+                      name="collectionUid"
+                      value={this.state.collectionUid}
+                      variant="outlined"
+                      onChange={this.handleCollectionChange}
+                    >
+                      {this.props.collections.map((x) => (
+                        <MenuItem key={x.collection.uid} value={x.collection.uid}>{x.metadata.name}</MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
                 </Grid>
-                <Grid item>
+              </Grid>
+
+              <Grid container item direction="row" spacing={2}>
+                <Grid item xs="auto">
+                  <IconPerson style={{ paddingTop: "1rem" }} />
+                </Grid>
+
+                <Grid container item direction="column" spacing={2} xs>
+                  {(this.state.showAllNameFields || this.state.namePrefix) &&
+                    <Grid item>
+                      <TextField
+                        name="namePrefix"
+                        label="Prefix"
+                        variant="outlined"
+                        style={{ ...styles.fullWidth }}
+                        value={this.state.namePrefix}
+                        onChange={this.handleInputChange}
+                      />
+                    </Grid>
+                  }
+
+                  <Grid item>
+                    <TextField
+                      name="firstName"
+                      label="First name"
+                      variant="outlined"
+                      style={{ ...styles.fullWidth }}
+                      value={this.state.firstName}
+                      onChange={this.handleInputChange}
+                    />
+                  </Grid>
+
+                  {(this.state.showAllNameFields || this.state.middleName) &&
+                    <Grid item>
+                      <TextField
+                        name="middleName"
+                        label="Middle name"
+                        variant="outlined"
+                        style={{ ...styles.fullWidth }}
+                        value={this.state.middleName}
+                        onChange={this.handleInputChange}
+                      />
+                    </Grid>
+                  }
+
+                  <Grid item>
+                    <TextField
+                      name="lastName"
+                      label="Last name"
+                      variant="outlined"
+                      style={{ ...styles.fullWidth }}
+                      value={this.state.lastName}
+                      onChange={this.handleInputChange}
+                    />
+                  </Grid>
+
+                  {(this.state.showAllNameFields || this.state.nameSuffix) &&
+                    <Grid item>
+                      <TextField
+                        name="nameSuffix"
+                        label="Suffix"
+                        variant="outlined"
+                        style={{ ...styles.fullWidth }}
+                        value={this.state.nameSuffix}
+                        onChange={this.handleInputChange}
+                      />
+                    </Grid>
+                  }
+                </Grid>
+
+                <Grid item xs="auto">
+                  <IconButton
+                    onClick={() => this.setState({ showAllNameFields: !this.state.showAllNameFields })}
+                    title="Show all name fields"
+                  >
+                    {this.state.showAllNameFields ? <IconExpandLess /> : <IconExpandMore />}
+                  </IconButton>
+                </Grid>
+              </Grid>
+
+              <Grid container item direction="row" spacing={2}>
+                <Grid item xs="auto">
+                  <IconPhone style={{ paddingTop: "1rem" }} />
+                </Grid>
+
+                <Grid container item direction="column" spacing={2} xs>
+                  {this.state.phone.map((x, idx) => (
+                    <ValueTypeComponent
+                      key={idx}
+                      name="phone"
+                      placeholder="Phone"
+                      types={telTypes}
+                      typeLabel="Label"
+                      value={x}
+                      style={{ ...styles.fullWidth }}
+                      onClearRequest={(name: string) => this.removeValueType(name, idx)}
+                      onChange={(name: string, type: string, value: string) => (
+                        this.handleValueTypeChange(name, idx, { type, value })
+                      )}
+                    />
+                  ))}
+
+                  <Grid item xs="auto">
+                    <Button
+                      onClick={() => this.addValueType("phone")}
+                      color="secondary"
+                      variant="outlined"
+                      style={{ height: "3.5rem", fontSize: "1em" }}
+                    >
+                      Add phone number
+                    </Button>
+                  </Grid>
+                </Grid>
+              </Grid>
+
+              <Grid container item direction="row" spacing={2}>
+                <Grid item xs="auto">
+                  <IconOrganization style={{ paddingTop: "1rem" }} />
+                </Grid>
+
+                <Grid container item direction="column" spacing={2} xs>
+                  <Grid item>
+                    <TextField
+                      name="org"
+                      label="Organization"
+                      variant="outlined"
+                      style={styles.fullWidth}
+                      value={this.state.org}
+                      onChange={this.handleInputChange}
+                    />
+                  </Grid>
+                  <Grid item>
+                    <TextField
+                      name="title"
+                      label="Title"
+                      variant="outlined"
+                      style={styles.fullWidth}
+                      value={this.state.title}
+                      onChange={this.handleInputChange}
+                    />
+                  </Grid>
+                </Grid>
+              </Grid>
+
+              <Grid container item direction="row" spacing={2}>
+                <Grid item xs="auto">
+                  <IconEmail style={{ paddingTop: "1rem" }} />
+                </Grid>
+
+                <Grid container item direction="column" spacing={2} xs>
+                  {this.state.email.map((x, idx) => (
+                    <ValueTypeComponent
+                      key={idx}
+                      name="email"
+                      placeholder="Email"
+                      types={emailTypes}
+                      style={{ ...styles.fullWidth }}
+                      value={x}
+                      onClearRequest={(name: string) => this.removeValueType(name, idx)}
+                      onChange={(name: string, type: string, value: string) => (
+                        this.handleValueTypeChange(name, idx, { type, value })
+                      )}
+                    />
+                  ))}
+                  <Grid item xs="auto">
+                    <Button
+                      onClick={() => this.addValueType("email")}
+                      color="secondary"
+                      variant="outlined"
+                      style={{ height: "3.5rem", fontSize: "1em" }}
+                    >
+                      Add email address
+                    </Button>
+                  </Grid>
+                </Grid>
+              </Grid>
+
+              <Grid container item direction="row" spacing={2}>
+                <Grid item xs="auto">
+                  <IconImpp style={{ paddingTop: "1rem" }} />
+                </Grid>
+
+                <Grid container item direction="column" spacing={2} xs>
+                  {this.state.impp.map((x, idx) => (
+                    <ValueTypeComponent
+                      key={idx}
+                      name="impp"
+                      placeholder="IMPP"
+                      types={imppTypes}
+                      style={{ ...styles.fullWidth }}
+                      value={x}
+                      onClearRequest={(name: string) => this.removeValueType(name, idx)}
+                      onChange={(name: string, type: string, value: string) => (
+                        this.handleValueTypeChange(name, idx, { type, value })
+                      )}
+                    />
+                  ))}
+                  <Grid item xs="auto">
+                    <Button
+                      onClick={() => this.addValueType("impp", "jabber")}
+                      color="secondary"
+                      variant="outlined"
+                      style={{ height: "3.5rem", fontSize: "1em" }}
+                    >
+                      Add impp address
+                    </Button>
+                  </Grid>
+                </Grid>
+              </Grid>
+
+              <Grid container item direction="row" spacing={2}>
+                <Grid item xs="auto">
+                  <IconAddress style={{ paddingTop: "1rem" }} />
+                </Grid>
+
+                <Grid container item direction="column" spacing={2} xs>
+                  {this.state.address.map((x, idx) => (
+                    <ValueTypeComponent
+                      key={idx}
+                      name="address"
+                      placeholder="Address"
+                      types={addressTypes}
+                      style={{ ...styles.fullWidth }}
+                      multiline
+                      value={x}
+                      onClearRequest={(name: string) => this.removeValueType(name, idx)}
+                      onChange={(name: string, type: string, value: string) => (
+                        this.handleValueTypeChange(name, idx, { type, value })
+                      )}
+                    />
+                  ))}
+                  <Grid item xs="auto">
+                    <Button
+                      onClick={() => this.addValueType("address")}
+                      color="secondary"
+                      variant="outlined"
+                      style={{ height: "3.5rem", fontSize: "1em" }}
+                    >
+                      Add address
+                    </Button>
+                  </Grid>
+                </Grid>
+              </Grid>
+
+              <Grid container item direction="row" spacing={2}>
+                <Grid item xs="auto">
+                  <IconNote style={{ paddingTop: "1rem" }} />
+                </Grid>
+
+                <Grid item xs>
                   <TextField
-                    name="title"
-                    label="Title"
-                    variant="outlined"
-                    style={styles.fullWidth}
-                    value={this.state.title}
-                    onChange={this.handleInputChange}
-                  />
-                </Grid>
-              </Grid>
-            </Grid>
-
-            <Grid container item direction="row" spacing={2}>
-              <Grid item xs="auto">
-                <IconEmail style={{ paddingTop: "1rem" }} />
-              </Grid>
-
-              <Grid container item direction="column" spacing={2} xs>
-                {this.state.email.map((x, idx) => (
-                  <ValueTypeComponent
-                    key={idx}
-                    name="email"
-                    placeholder="Email"
-                    types={emailTypes}
-                    style={{ ...styles.fullWidth }}
-                    value={x}
-                    onClearRequest={(name: string) => this.removeValueType(name, idx)}
-                    onChange={(name: string, type: string, value: string) => (
-                      this.handleValueTypeChange(name, idx, { type, value })
-                    )}
-                  />
-                ))}
-                <Grid item xs="auto">
-                  <Button
-                    onClick={() => this.addValueType("email")}
-                    color="secondary"
-                    variant="outlined"
-                    style={{ height: "3.5rem", fontSize: "1em" }}
-                  >
-                    Add email address
-                  </Button>
-                </Grid>
-              </Grid>
-            </Grid>
-
-            <Grid container item direction="row" spacing={2}>
-              <Grid item xs="auto">
-                <IconImpp style={{ paddingTop: "1rem" }} />
-              </Grid>
-
-              <Grid container item direction="column" spacing={2} xs>
-                {this.state.impp.map((x, idx) => (
-                  <ValueTypeComponent
-                    key={idx}
-                    name="impp"
-                    placeholder="IMPP"
-                    types={imppTypes}
-                    style={{ ...styles.fullWidth }}
-                    value={x}
-                    onClearRequest={(name: string) => this.removeValueType(name, idx)}
-                    onChange={(name: string, type: string, value: string) => (
-                      this.handleValueTypeChange(name, idx, { type, value })
-                    )}
-                  />
-                ))}
-                <Grid item xs="auto">
-                  <Button
-                    onClick={() => this.addValueType("impp", "jabber")}
-                    color="secondary"
-                    variant="outlined"
-                    style={{ height: "3.5rem", fontSize: "1em" }}
-                  >
-                    Add impp address
-                  </Button>
-                </Grid>
-              </Grid>
-            </Grid>
-
-            <Grid container item direction="row" spacing={2}>
-              <Grid item xs="auto">
-                <IconAddress style={{ paddingTop: "1rem" }} />
-              </Grid>
-
-              <Grid container item direction="column" spacing={2} xs>
-                {this.state.address.map((x, idx) => (
-                  <ValueTypeComponent
-                    key={idx}
-                    name="address"
-                    placeholder="Address"
-                    types={addressTypes}
-                    style={{ ...styles.fullWidth }}
+                    name="note"
                     multiline
-                    value={x}
-                    onClearRequest={(name: string) => this.removeValueType(name, idx)}
-                    onChange={(name: string, type: string, value: string) => (
-                      this.handleValueTypeChange(name, idx, { type, value })
+                    label="Note"
+                    variant="outlined"
+                    style={styles.fullWidth}
+                    value={this.state.note}
+                    onChange={this.handleInputChange}
+                  />
+                </Grid>
+              </Grid>
+
+              <Grid container item direction="row" spacing={2}>
+                <Grid item xs="auto">
+                  <IconGroup style={{ paddingTop: "1rem" }} />
+                </Grid>
+
+                <Grid item xs>
+                  <Autocomplete
+                    style={styles.fullWidth}
+                    freeSolo
+                    multiple
+                    clearOnBlur
+                    selectOnFocus
+                    options={Object.keys(this.state.collectionGroups)}
+                    value={this.state.newGroups}
+                    onChange={(_e, value) => this.handleChange("newGroups", value)}
+                    renderInput={(params) => (
+                      <TextField
+                        {...params}
+                        variant="outlined"
+                        label="Groups"
+                        fullWidth
+                      />
                     )}
                   />
-                ))}
-                <Grid item xs="auto">
-                  <Button
-                    onClick={() => this.addValueType("address")}
-                    color="secondary"
-                    variant="outlined"
-                    style={{ height: "3.5rem", fontSize: "1em" }}
-                  >
-                    Add address
-                  </Button>
                 </Grid>
               </Grid>
             </Grid>
 
-            <Grid container item direction="row" spacing={2}>
-              <Grid item xs="auto">
-                <IconNote style={{ paddingTop: "1rem" }} />
-              </Grid>
-
-              <Grid item xs>
-                <TextField
-                  name="note"
-                  multiline
-                  label="Note"
-                  variant="outlined"
-                  style={styles.fullWidth}
-                  value={this.state.note}
-                  onChange={this.handleInputChange}
-                />
-              </Grid>
-            </Grid>
-
-            <Grid container item direction="row" spacing={2}>
-              <Grid item xs="auto">
-                <IconGroup style={{ paddingTop: "1rem" }} />
-              </Grid>
-
-              <Grid item xs>
-                <Autocomplete
-                  style={styles.fullWidth}
-                  freeSolo
-                  multiple
-                  clearOnBlur
-                  selectOnFocus
-                  options={Object.keys(this.state.collectionGroups)}
-                  value={this.state.newGroups}
-                  onChange={(_e, value) => this.handleChange("newGroups", value)}
-                  renderInput={(params) => (
-                    <TextField
-                      {...params}
-                      variant="outlined"
-                      label="Groups"
-                      fullWidth
-                    />
-                  )}
-                />
-              </Grid>
-            </Grid>
-          </Grid>
-
-          <div style={styles.submit}>
-            <Button
-              variant="contained"
-              onClick={this.props.onCancel}
-            >
-              <IconCancel style={{ marginRight: 8 }} />
-              Cancel
-            </Button>
-
-            {this.props.item &&
+            <div style={styles.submit}>
               <Button
                 variant="contained"
-                style={{ marginLeft: 15, backgroundColor: colors.red[500], color: "white" }}
-                onClick={this.onDeleteRequest}
+                onClick={this.props.onCancel}
               >
-                <IconDelete style={{ marginRight: 8 }} />
-                Delete
+                <IconCancel style={{ marginRight: 8 }} />
+                Cancel
               </Button>
-            }
 
-            <Button
-              type="submit"
-              variant="contained"
-              color="secondary"
-              style={{ marginLeft: 15 }}
-            >
-              <IconSave style={{ marginRight: 8 }} />
-              Save
-            </Button>
-          </div>
-        </form>
+              {this.props.item &&
+                <Button
+                  variant="contained"
+                  style={{ marginLeft: 15, backgroundColor: colors.red[500], color: "white" }}
+                  onClick={this.onDeleteRequest}
+                >
+                  <IconDelete style={{ marginRight: 8 }} />
+                  Delete
+                </Button>
+              }
+
+              <Button
+                type="submit"
+                variant="contained"
+                color="secondary"
+                style={{ marginLeft: 15 }}
+              >
+                <IconSave style={{ marginRight: 8 }} />
+                Save
+              </Button>
+            </div>
+          </form>
+        </div>
 
         <ConfirmationDialog
           title="Delete Confirmation"

--- a/src/Contacts/ContactEdit.tsx
+++ b/src/Contacts/ContactEdit.tsx
@@ -12,10 +12,17 @@ import InputLabel from "@material-ui/core/InputLabel";
 import * as colors from "@material-ui/core/colors";
 
 import IconDelete from "@material-ui/icons/Delete";
-import IconAdd from "@material-ui/icons/Add";
 import IconClear from "@material-ui/icons/Clear";
 import IconCancel from "@material-ui/icons/Clear";
 import IconSave from "@material-ui/icons/Save";
+import IconPerson from "@material-ui/icons/PersonOutlined";
+import IconOrganization from "@material-ui/icons/BusinessOutlined";
+import IconPhone from "@material-ui/icons/PhoneOutlined";
+import IconEmail from "@material-ui/icons/EmailOutlined";
+import IconImpp from "@material-ui/icons/SmsOutlined";
+import IconAddress from "@material-ui/icons/LocationOnOutlined";
+import IconNote from "@material-ui/icons/EditOutlined";
+import IconGroup from "@material-ui/icons/GroupOutlined";
 
 import ConfirmationDialog from "../widgets/ConfirmationDialog";
 
@@ -28,6 +35,7 @@ import { ContactType } from "../pim-types";
 
 import { History } from "history";
 import Autocomplete from "@material-ui/lab/Autocomplete";
+import { Grid } from "@material-ui/core";
 
 const telTypes = [
   { type: "Home" },
@@ -57,6 +65,7 @@ const TypeSelector = (props: any) => {
     <Select
       style={props.style}
       value={props.value}
+      variant="outlined"
       onChange={props.onChange}
     >
       {types.map((x) => (
@@ -78,6 +87,7 @@ class ValueType {
 
 interface ValueTypeComponentProps {
   type?: string;
+  typeLabel?: string;
   style?: object;
   multiline?: boolean;
 
@@ -92,27 +102,41 @@ interface ValueTypeComponentProps {
 const ValueTypeComponent = (props: ValueTypeComponentProps) => {
   return (
     <React.Fragment>
-      <TextField
-        type={props.type}
-        placeholder={props.placeholder}
-        multiline={props.multiline}
-        style={props.style}
-        value={props.value.value}
-        onChange={(event: React.ChangeEvent<any>) => props.onChange(props.name, props.value.type, event.target.value)}
-      />
-      <IconButton
-        onClick={() => props.onClearRequest(props.name)}
-        title="Remove"
-      >
-        <IconClear />
-      </IconButton>
-      <TypeSelector
-        value={props.value.type}
-        types={props.types}
-        onChange={(event: React.ChangeEvent<HTMLSelectElement>) => (
-          props.onChange(props.name, event.target.value, props.value.value)
-        )}
-      />
+      <Grid container item direction="row" spacing={2} alignItems="center">
+        <Grid item xs>
+          <TextField
+            type={props.type}
+            label={props.placeholder}
+            multiline={props.multiline}
+            variant="outlined"
+            style={props.style}
+            value={props.value.value}
+            onChange={(event: React.ChangeEvent<any>) => props.onChange(props.name, props.value.type, event.target.value)}
+          />
+        </Grid>
+
+        <Grid item xs="auto">
+          <TypeSelector
+            value={props.value.type}
+            lable={props.typeLabel}
+            types={props.types}
+            onChange={(event: React.ChangeEvent<HTMLSelectElement>) => (
+              props.onChange(props.name, event.target.value, props.value.value)
+            )}
+          />
+        </Grid>
+
+        <Grid item xs="auto">
+          <IconButton
+            onClick={() => props.onClearRequest(props.name)}
+            title="Remove"
+          >
+            <IconClear />
+          </IconButton>
+        </Grid>
+      </Grid> 
+      
+      
     </React.Fragment>
   );
 };
@@ -485,181 +509,279 @@ class ContactEdit extends React.PureComponent<PropsType> {
             </Select>
           </FormControl>
 
-          <TextField
-            name="namePrefix"
-            label="Prefix"
-            style={{ marginTop: "2rem", ...styles.fullWidth }}
-            value={this.state.namePrefix}
-            onChange={this.handleInputChange}
-          />
+          <Grid container direction="column" spacing={4} style={{ marginTop: "1.5rem", marginBottom: "1.5rem", paddingLeft: "0.5rem", paddingRight: "1rem" }}>
+            <Grid container item direction="row" spacing={2}>
+              <Grid item xs="auto">
+                <IconPerson style={{ paddingTop: "1rem" }} />
+              </Grid>
 
-          <TextField
-            name="firstName"
-            label="First name"
-            style={{ marginTop: "2rem", ...styles.fullWidth }}
-            value={this.state.firstName}
-            onChange={this.handleInputChange}
-          />
+              <Grid container item direction="column" spacing={2} xs>
+                <Grid item>
+                  <TextField
+                    name="namePrefix"
+                    label="Prefix"
+                    variant="outlined"
+                    style={{ ...styles.fullWidth }}
+                    value={this.state.namePrefix}
+                    onChange={this.handleInputChange}
+                  />
+                </Grid>                
 
-          <TextField
-            name="middleName"
-            label="Middle name"
-            style={{ marginTop: "2rem", ...styles.fullWidth }}
-            value={this.state.middleName}
-            onChange={this.handleInputChange}
-          />
+                <Grid item>
+                  <TextField
+                    name="firstName"
+                    label="First name"
+                    variant="outlined"
+                    style={{ ...styles.fullWidth }}
+                    value={this.state.firstName}
+                    onChange={this.handleInputChange}
+                  />
+                </Grid>
 
-          <TextField
-            name="lastName"
-            label="Last name"
-            style={{ marginTop: "2rem", ...styles.fullWidth }}
-            value={this.state.lastName}
-            onChange={this.handleInputChange}
-          />
+                <Grid item>
+                  <TextField
+                    name="middleName"
+                    label="Middle name"
+                    variant="outlined"
+                    style={{ ...styles.fullWidth }}
+                    value={this.state.middleName}
+                    onChange={this.handleInputChange}
+                  />
+                </Grid>
 
-          <TextField
-            name="nameSuffix"
-            label="Suffix"
-            style={{ marginTop: "2rem", ...styles.fullWidth }}
-            value={this.state.nameSuffix}
-            onChange={this.handleInputChange}
-          />
+                <Grid item>
+                  <TextField
+                    name="lastName"
+                    label="Last name"
+                    variant="outlined"
+                    style={{ ...styles.fullWidth }}
+                    value={this.state.lastName}
+                    onChange={this.handleInputChange}
+                  />
+                </Grid>
 
-          <div>
-            Phone numbers
-            <IconButton
-              onClick={() => this.addValueType("phone")}
-              title="Add phone number"
-            >
-              <IconAdd />
-            </IconButton>
-          </div>
-          {this.state.phone.map((x, idx) => (
-            <ValueTypeComponent
-              key={idx}
-              name="phone"
-              placeholder="Phone"
-              types={telTypes}
-              value={x}
-              onClearRequest={(name: string) => this.removeValueType(name, idx)}
-              onChange={(name: string, type: string, value: string) => (
-                this.handleValueTypeChange(name, idx, { type, value })
-              )}
-            />
-          ))}
+                <Grid item>
+                  <TextField
+                    name="nameSuffix"
+                    label="Suffix"
+                    variant="outlined"
+                    style={{ ...styles.fullWidth }}
+                    value={this.state.nameSuffix}
+                    onChange={this.handleInputChange}
+                  />
+                </Grid>
+              </Grid>
+            </Grid>
 
-          <div>
-            Emails
-            <IconButton
-              onClick={() => this.addValueType("email")}
-              title="Add email address"
-            >
-              <IconAdd />
-            </IconButton>
-          </div>
-          {this.state.email.map((x, idx) => (
-            <ValueTypeComponent
-              key={idx}
-              name="email"
-              placeholder="Email"
-              types={emailTypes}
-              value={x}
-              onClearRequest={(name: string) => this.removeValueType(name, idx)}
-              onChange={(name: string, type: string, value: string) => (
-                this.handleValueTypeChange(name, idx, { type, value })
-              )}
-            />
-          ))}
+            <Grid container item direction="row" spacing={2}>
+              <Grid item xs="auto">
+                <IconOrganization style={{ paddingTop: "1rem" }} />
+              </Grid>
 
-          <div>
-            IMPP
-            <IconButton
-              onClick={() => this.addValueType("impp", "jabber")}
-              title="Add impp address"
-            >
-              <IconAdd />
-            </IconButton>
-          </div>
-          {this.state.impp.map((x, idx) => (
-            <ValueTypeComponent
-              key={idx}
-              name="impp"
-              placeholder="IMPP"
-              types={imppTypes}
-              value={x}
-              onClearRequest={(name: string) => this.removeValueType(name, idx)}
-              onChange={(name: string, type: string, value: string) => (
-                this.handleValueTypeChange(name, idx, { type, value })
-              )}
-            />
-          ))}
+              <Grid container item direction="column" spacing={2} xs>
+                <Grid item>
+                  <TextField
+                    name="org"
+                    label="Organization"
+                    variant="outlined"
+                    style={styles.fullWidth}
+                    value={this.state.org}
+                    onChange={this.handleInputChange}
+                  />
+                </Grid>
+                <Grid item>
+                  <TextField
+                    name="title"
+                    label="Title"
+                    variant="outlined"
+                    style={styles.fullWidth}
+                    value={this.state.title}
+                    onChange={this.handleInputChange}
+                  />
+                </Grid>
+              </Grid>
+            </Grid>
 
-          <div>
-            Addresses
-            <IconButton
-              onClick={() => this.addValueType("address")}
-              title="Add address"
-            >
-              <IconAdd />
-            </IconButton>
-          </div>
-          {this.state.address.map((x, idx) => (
-            <ValueTypeComponent
-              key={idx}
-              name="address"
-              placeholder="Address"
-              types={addressTypes}
-              multiline
-              value={x}
-              onClearRequest={(name: string) => this.removeValueType(name, idx)}
-              onChange={(name: string, type: string, value: string) => (
-                this.handleValueTypeChange(name, idx, { type, value })
-              )}
-            />
-          ))}
+            <Grid container item direction="row" spacing={2}>
+              <Grid item xs="auto">
+                <IconPhone style={{ paddingTop: "1rem" }} />
+              </Grid>
 
-          <TextField
-            name="org"
-            label="Organization"
-            style={styles.fullWidth}
-            value={this.state.org}
-            onChange={this.handleInputChange}
-          />
+              <Grid container item direction="column" spacing={2} xs>
+                {this.state.phone.map((x, idx) => (
+                  <ValueTypeComponent
+                    key={idx}
+                    name="phone"
+                    placeholder="Phone"
+                    types={telTypes}
+                    typeLabel="Label"
+                    value={x}
+                    style={{ ...styles.fullWidth }}
+                    onClearRequest={(name: string) => this.removeValueType(name, idx)}
+                    onChange={(name: string, type: string, value: string) => (
+                      this.handleValueTypeChange(name, idx, { type, value })
+                    )}
+                  />
+                ))}
 
-          <TextField
-            name="title"
-            label="Title"
-            style={styles.fullWidth}
-            value={this.state.title}
-            onChange={this.handleInputChange}
-          />
+                <Grid item xs="auto">
+                  <Button
+                    onClick={() => this.addValueType("phone")}
+                    color="secondary"
+                    variant="outlined"
+                    style={{ height: "3.5rem", fontSize: "1em" }}
+                  >
+                    Add phone number
+                  </Button>
+                </Grid>
+              </Grid>
+            </Grid>
 
-          <TextField
-            name="note"
-            multiline
-            label="Note"
-            style={styles.fullWidth}
-            value={this.state.note}
-            onChange={this.handleInputChange}
-          />
-          <Autocomplete
-            style={styles.fullWidth}
-            freeSolo
-            multiple
-            clearOnBlur
-            selectOnFocus
-            options={Object.keys(this.state.collectionGroups)}
-            value={this.state.newGroups}
-            onChange={(_e, value) => this.handleChange("newGroups", value)}
-            renderInput={(params) => (
-              <TextField
-                {...params}
-                variant="standard"
-                label="Groups"
-                fullWidth
-              />
-            )}
-          />
+            <Grid container item direction="row" spacing={2}>
+              <Grid item xs="auto">
+                <IconEmail style={{ paddingTop: "1rem" }} />
+              </Grid>
+
+              <Grid container item direction="column" spacing={2} xs>
+                {this.state.email.map((x, idx) => (
+                  <ValueTypeComponent
+                    key={idx}
+                    name="email"
+                    placeholder="Email"
+                    types={emailTypes}
+                    style={{ ...styles.fullWidth }}
+                    value={x}
+                    onClearRequest={(name: string) => this.removeValueType(name, idx)}
+                    onChange={(name: string, type: string, value: string) => (
+                      this.handleValueTypeChange(name, idx, { type, value })
+                    )}
+                  />
+                ))}
+                <Grid item xs="auto">
+                  <Button
+                    onClick={() => this.addValueType("email")}
+                    color="secondary"
+                    variant="outlined"
+                    style={{ height: "3.5rem", fontSize: "1em" }}
+                  >
+                    Add email address
+                  </Button>
+                </Grid>
+              </Grid>
+            </Grid>
+
+            <Grid container item direction="row" spacing={2}>
+              <Grid item xs="auto">
+                <IconImpp style={{ paddingTop: "1rem" }} />
+              </Grid>
+
+              <Grid container item direction="column" spacing={2} xs>
+                {this.state.impp.map((x, idx) => (
+                  <ValueTypeComponent
+                    key={idx}
+                    name="impp"
+                    placeholder="IMPP"
+                    types={imppTypes}
+                    style={{ ...styles.fullWidth }}
+                    value={x}
+                    onClearRequest={(name: string) => this.removeValueType(name, idx)}
+                    onChange={(name: string, type: string, value: string) => (
+                      this.handleValueTypeChange(name, idx, { type, value })
+                    )}
+                  />
+                ))}
+                <Grid item xs="auto">
+                  <Button
+                    onClick={() => this.addValueType("impp", "jabber")}
+                    color="secondary"
+                    variant="outlined"
+                    style={{ height: "3.5rem", fontSize: "1em" }}
+                  >
+                    Add impp address
+                  </Button>
+                </Grid>
+              </Grid>
+            </Grid>
+
+            <Grid container item direction="row" spacing={2}>
+              <Grid item xs="auto">
+                <IconAddress style={{ paddingTop: "1rem" }} />
+              </Grid>
+
+              <Grid container item direction="column" spacing={2} xs>
+                {this.state.address.map((x, idx) => (
+                  <ValueTypeComponent
+                    key={idx}
+                    name="address"
+                    placeholder="Address"
+                    types={addressTypes}
+                    style={{ ...styles.fullWidth }}
+                    multiline
+                    value={x}
+                    onClearRequest={(name: string) => this.removeValueType(name, idx)}
+                    onChange={(name: string, type: string, value: string) => (
+                      this.handleValueTypeChange(name, idx, { type, value })
+                    )}
+                  />
+                ))}
+                <Grid item xs="auto">
+                  <Button
+                    onClick={() => this.addValueType("address")}
+                    color="secondary"
+                    variant="outlined"
+                    style={{ height: "3.5rem", fontSize: "1em" }}
+                  >
+                    Add address
+                  </Button>
+                </Grid>
+              </Grid>
+            </Grid>
+
+            <Grid container item direction="row" spacing={2}>
+              <Grid item xs="auto">
+                <IconNote style={{ paddingTop: "1rem" }} />
+              </Grid>
+
+              <Grid item xs>
+                <TextField
+                  name="note"
+                  multiline
+                  label="Note"
+                  variant="outlined"
+                  style={styles.fullWidth}
+                  value={this.state.note}
+                  onChange={this.handleInputChange}
+                />
+              </Grid>
+            </Grid>
+
+            <Grid container item direction="row" spacing={2}>
+              <Grid item xs="auto">
+                <IconGroup style={{ paddingTop: "1rem" }} />
+              </Grid>
+
+              <Grid item xs>
+                <Autocomplete
+                  style={styles.fullWidth}
+                  freeSolo
+                  multiple
+                  clearOnBlur
+                  selectOnFocus
+                  options={Object.keys(this.state.collectionGroups)}
+                  value={this.state.newGroups}
+                  onChange={(_e, value) => this.handleChange("newGroups", value)}
+                  renderInput={(params) => (
+                    <TextField
+                      {...params}
+                      variant="outlined"
+                      label="Groups"
+                      fullWidth
+                    />
+                  )}
+                />
+              </Grid>
+            </Grid>
+          </Grid>
 
           <div style={styles.submit}>
             <Button

--- a/src/Contacts/ContactEdit.tsx
+++ b/src/Contacts/ContactEdit.tsx
@@ -23,6 +23,8 @@ import IconImpp from "@material-ui/icons/SmsOutlined";
 import IconAddress from "@material-ui/icons/LocationOnOutlined";
 import IconNote from "@material-ui/icons/EditOutlined";
 import IconGroup from "@material-ui/icons/GroupOutlined";
+import IconExpandMore from "@material-ui/icons/ExpandMoreOutlined";
+import IconExpandLess from "@material-ui/icons/ExpandLessOutlined";
 
 import ConfirmationDialog from "../widgets/ConfirmationDialog";
 
@@ -174,6 +176,8 @@ class ContactEdit extends React.PureComponent<PropsType> {
     collectionGroups: {};
     newGroups: string[];
     originalGroups: {};
+
+    showAllNameFields: boolean;
   };
 
   constructor(props: PropsType) {
@@ -199,6 +203,8 @@ class ContactEdit extends React.PureComponent<PropsType> {
       collectionGroups: {},
       newGroups: [],
       originalGroups: [],
+
+      showAllNameFields: false,
     };
 
     if (this.props.item !== undefined) {
@@ -500,7 +506,7 @@ class ContactEdit extends React.PureComponent<PropsType> {
                 <IconSaveTo style={{ paddingTop: "1rem" }} />
               </Grid>
 
-              <Grid item>
+              <Grid item xs="auto">
                 <FormControl
                   disabled={this.props.item !== undefined}
                   style={styles.fullWidth}
@@ -525,16 +531,18 @@ class ContactEdit extends React.PureComponent<PropsType> {
               </Grid>
 
               <Grid container item direction="column" spacing={2} xs>
-                <Grid item>
-                  <TextField
-                    name="namePrefix"
-                    label="Prefix"
-                    variant="outlined"
-                    style={{ ...styles.fullWidth }}
-                    value={this.state.namePrefix}
-                    onChange={this.handleInputChange}
-                  />
-                </Grid>                
+                {(this.state.showAllNameFields || this.state.namePrefix) &&
+                  <Grid item>
+                    <TextField
+                      name="namePrefix"
+                      label="Prefix"
+                      variant="outlined"
+                      style={{ ...styles.fullWidth }}
+                      value={this.state.namePrefix}
+                      onChange={this.handleInputChange}
+                    />
+                  </Grid>
+                }
 
                 <Grid item>
                   <TextField
@@ -547,16 +555,18 @@ class ContactEdit extends React.PureComponent<PropsType> {
                   />
                 </Grid>
 
-                <Grid item>
-                  <TextField
-                    name="middleName"
-                    label="Middle name"
-                    variant="outlined"
-                    style={{ ...styles.fullWidth }}
-                    value={this.state.middleName}
-                    onChange={this.handleInputChange}
-                  />
-                </Grid>
+                {(this.state.showAllNameFields || this.state.middleName) &&
+                  <Grid item>
+                    <TextField
+                      name="middleName"
+                      label="Middle name"
+                      variant="outlined"
+                      style={{ ...styles.fullWidth }}
+                      value={this.state.middleName}
+                      onChange={this.handleInputChange}
+                    />
+                  </Grid>
+                }
 
                 <Grid item>
                   <TextField
@@ -569,16 +579,27 @@ class ContactEdit extends React.PureComponent<PropsType> {
                   />
                 </Grid>
 
-                <Grid item>
-                  <TextField
-                    name="nameSuffix"
-                    label="Suffix"
-                    variant="outlined"
-                    style={{ ...styles.fullWidth }}
-                    value={this.state.nameSuffix}
-                    onChange={this.handleInputChange}
-                  />
-                </Grid>
+                {(this.state.showAllNameFields || this.state.nameSuffix) &&
+                  <Grid item>
+                    <TextField
+                      name="nameSuffix"
+                      label="Suffix"
+                      variant="outlined"
+                      style={{ ...styles.fullWidth }}
+                      value={this.state.nameSuffix}
+                      onChange={this.handleInputChange}
+                    />
+                  </Grid>
+                }
+              </Grid>
+
+              <Grid item xs="auto">
+                <IconButton
+                  onClick={() => this.setState({ showAllNameFields: !this.state.showAllNameFields })}
+                  title="Show all name fields"
+                >
+                  {this.state.showAllNameFields ? <IconExpandLess /> : <IconExpandMore />}
+                </IconButton>
               </Grid>
             </Grid>
 

--- a/src/Contacts/ContactEdit.tsx
+++ b/src/Contacts/ContactEdit.tsx
@@ -246,10 +246,21 @@ class ContactEdit extends React.PureComponent<PropsType> {
         ))
       );
 
-      this.state.phone = propToValueType(contact.comp, "tel");
-      this.state.email = propToValueType(contact.comp, "email");
-      this.state.address = propToValueType(contact.comp, "adr");
-      this.state.impp = propToValueType(contact.comp, "impp");
+      if (propToValueType(contact.comp, "tel").length > 0) {
+        this.state.phone = propToValueType(contact.comp, "tel");
+      }
+
+      if (propToValueType(contact.comp, "email").length > 0) {
+        this.state.email = propToValueType(contact.comp, "email");
+      }
+
+      if (propToValueType(contact.comp, "adr").length > 0) {
+        this.state.address = propToValueType(contact.comp, "adr");
+      }
+
+      if (propToValueType(contact.comp, "impp").length > 0) {
+        this.state.impp = propToValueType(contact.comp, "impp");
+      }
 
       const propToStringType = (comp: ICAL.Component, propName: string) => {
         const val = comp.getFirstPropertyValue(propName);
@@ -303,14 +314,22 @@ class ContactEdit extends React.PureComponent<PropsType> {
     });
   }
 
-  public removeValueType(name: string, idx: number) {
+  public removeValueType(name: string, idx: number, type?: string) {
     this.setState((prevState) => {
       const newArray = prevState[name].slice(0);
       newArray.splice(idx, 1);
-      return {
-        ...prevState,
-        [name]: newArray,
-      };
+
+      if (newArray.length < 1) {
+        return {
+          ...prevState,
+          [name]: [new ValueType(type)],
+        };
+      } else {
+        return {
+          ...prevState,
+          [name]: newArray,
+        };
+      }
     });
   }
 
@@ -452,7 +471,7 @@ class ContactEdit extends React.PureComponent<PropsType> {
     setProperties("tel", this.state.phone);
     setProperties("email", this.state.email);
     setProperties("adr", this.state.address);
-    setProperties("impp", this.state.impp.map((x) => (
+    setProperties("impp", this.state.impp.filter((element) => element.value !== "").map((x) => (
       { type: x.type, value: x.type + ":" + x.value }
     )));
 
@@ -630,8 +649,7 @@ class ContactEdit extends React.PureComponent<PropsType> {
                     <Button
                       onClick={() => this.addValueType("phone")}
                       color="secondary"
-                      variant="outlined"
-                      style={{ height: "3.5rem", fontSize: "1em" }}
+                      size="small"
                     >
                       Add phone number
                     </Button>
@@ -692,8 +710,7 @@ class ContactEdit extends React.PureComponent<PropsType> {
                     <Button
                       onClick={() => this.addValueType("email")}
                       color="secondary"
-                      variant="outlined"
-                      style={{ height: "3.5rem", fontSize: "1em" }}
+                      size="small"
                     >
                       Add email address
                     </Button>
@@ -715,7 +732,7 @@ class ContactEdit extends React.PureComponent<PropsType> {
                       types={imppTypes}
                       style={{ ...styles.fullWidth }}
                       value={x}
-                      onClearRequest={(name: string) => this.removeValueType(name, idx)}
+                      onClearRequest={(name: string) => this.removeValueType(name, idx, "jabber")}
                       onChange={(name: string, type: string, value: string) => (
                         this.handleValueTypeChange(name, idx, { type, value })
                       )}
@@ -725,8 +742,7 @@ class ContactEdit extends React.PureComponent<PropsType> {
                     <Button
                       onClick={() => this.addValueType("impp", "jabber")}
                       color="secondary"
-                      variant="outlined"
-                      style={{ height: "3.5rem", fontSize: "1em" }}
+                      size="small"
                     >
                       Add impp address
                     </Button>
@@ -759,8 +775,7 @@ class ContactEdit extends React.PureComponent<PropsType> {
                     <Button
                       onClick={() => this.addValueType("address")}
                       color="secondary"
-                      variant="outlined"
-                      style={{ height: "3.5rem", fontSize: "1em" }}
+                      size="small"
                     >
                       Add address
                     </Button>

--- a/src/Contacts/ContactEdit.tsx
+++ b/src/Contacts/ContactEdit.tsx
@@ -8,6 +8,7 @@ import TextField from "@material-ui/core/TextField";
 import Select from "@material-ui/core/Select";
 import MenuItem from "@material-ui/core/MenuItem";
 import FormControl from "@material-ui/core/FormControl";
+import Grid from "@material-ui/core/Grid";
 import * as colors from "@material-ui/core/colors";
 
 import IconDelete from "@material-ui/icons/Delete";
@@ -37,7 +38,6 @@ import { ContactType } from "../pim-types";
 
 import { History } from "history";
 import Autocomplete from "@material-ui/lab/Autocomplete";
-import { Grid } from "@material-ui/core";
 
 const telTypes = [
   { type: "Home" },

--- a/src/Contacts/ContactEdit.tsx
+++ b/src/Contacts/ContactEdit.tsx
@@ -487,7 +487,7 @@ class ContactEdit extends React.PureComponent<PropsType> {
 
           <TextField
             name="namePrefix"
-            placeholder="Prefix"
+            label="Prefix"
             style={{ marginTop: "2rem", ...styles.fullWidth }}
             value={this.state.namePrefix}
             onChange={this.handleInputChange}
@@ -495,7 +495,7 @@ class ContactEdit extends React.PureComponent<PropsType> {
 
           <TextField
             name="firstName"
-            placeholder="First name"
+            label="First name"
             style={{ marginTop: "2rem", ...styles.fullWidth }}
             value={this.state.firstName}
             onChange={this.handleInputChange}
@@ -503,7 +503,7 @@ class ContactEdit extends React.PureComponent<PropsType> {
 
           <TextField
             name="middleName"
-            placeholder="Middle name"
+            label="Middle name"
             style={{ marginTop: "2rem", ...styles.fullWidth }}
             value={this.state.middleName}
             onChange={this.handleInputChange}
@@ -511,7 +511,7 @@ class ContactEdit extends React.PureComponent<PropsType> {
 
           <TextField
             name="lastName"
-            placeholder="Last name"
+            label="Last name"
             style={{ marginTop: "2rem", ...styles.fullWidth }}
             value={this.state.lastName}
             onChange={this.handleInputChange}
@@ -519,7 +519,7 @@ class ContactEdit extends React.PureComponent<PropsType> {
 
           <TextField
             name="nameSuffix"
-            placeholder="Suffix"
+            label="Suffix"
             style={{ marginTop: "2rem", ...styles.fullWidth }}
             value={this.state.nameSuffix}
             onChange={this.handleInputChange}
@@ -620,7 +620,7 @@ class ContactEdit extends React.PureComponent<PropsType> {
 
           <TextField
             name="org"
-            placeholder="Organization"
+            label="Organization"
             style={styles.fullWidth}
             value={this.state.org}
             onChange={this.handleInputChange}
@@ -628,7 +628,7 @@ class ContactEdit extends React.PureComponent<PropsType> {
 
           <TextField
             name="title"
-            placeholder="Title"
+            label="Title"
             style={styles.fullWidth}
             value={this.state.title}
             onChange={this.handleInputChange}
@@ -637,7 +637,7 @@ class ContactEdit extends React.PureComponent<PropsType> {
           <TextField
             name="note"
             multiline
-            placeholder="Note"
+            label="Note"
             style={styles.fullWidth}
             value={this.state.note}
             onChange={this.handleInputChange}

--- a/src/Contacts/ContactEdit.tsx
+++ b/src/Contacts/ContactEdit.tsx
@@ -575,35 +575,6 @@ class ContactEdit extends React.PureComponent<PropsType> {
 
             <Grid container item direction="row" spacing={2}>
               <Grid item xs="auto">
-                <IconOrganization style={{ paddingTop: "1rem" }} />
-              </Grid>
-
-              <Grid container item direction="column" spacing={2} xs>
-                <Grid item>
-                  <TextField
-                    name="org"
-                    label="Organization"
-                    variant="outlined"
-                    style={styles.fullWidth}
-                    value={this.state.org}
-                    onChange={this.handleInputChange}
-                  />
-                </Grid>
-                <Grid item>
-                  <TextField
-                    name="title"
-                    label="Title"
-                    variant="outlined"
-                    style={styles.fullWidth}
-                    value={this.state.title}
-                    onChange={this.handleInputChange}
-                  />
-                </Grid>
-              </Grid>
-            </Grid>
-
-            <Grid container item direction="row" spacing={2}>
-              <Grid item xs="auto">
                 <IconPhone style={{ paddingTop: "1rem" }} />
               </Grid>
 
@@ -633,6 +604,35 @@ class ContactEdit extends React.PureComponent<PropsType> {
                   >
                     Add phone number
                   </Button>
+                </Grid>
+              </Grid>
+            </Grid>
+
+            <Grid container item direction="row" spacing={2}>
+              <Grid item xs="auto">
+                <IconOrganization style={{ paddingTop: "1rem" }} />
+              </Grid>
+
+              <Grid container item direction="column" spacing={2} xs>
+                <Grid item>
+                  <TextField
+                    name="org"
+                    label="Organization"
+                    variant="outlined"
+                    style={styles.fullWidth}
+                    value={this.state.org}
+                    onChange={this.handleInputChange}
+                  />
+                </Grid>
+                <Grid item>
+                  <TextField
+                    name="title"
+                    label="Title"
+                    variant="outlined"
+                    style={styles.fullWidth}
+                    value={this.state.title}
+                    onChange={this.handleInputChange}
+                  />
                 </Grid>
               </Grid>
             </Grid>


### PR DESCRIPTION
I thought the current ContactEdit screen looks a bit messy, since the alignments and margins were a bit off in some places. So I tried to improve the situation a little.

This is a short summary of the changes I made:
- Use `Grid`-based layout
- Change `TextField` `placeholder` attributes to `label` so the name is still visible after input
- Switch `TextField` `variant`s from `standard` to `outlined` for a more modern look and more even looking spacing
- Add icons for better orientation
- Add button to show/hide name fields that are rarely used. Fields that have content are never hidden

Obviously, design stuff is a pretty subjective thing. So I'm not sure if you like this kind of layout or if this is the design direction you want to go in. This is simply a suggestion and I am happy to make adjustments.

Here is a small comparison:
Before:
<img width="1280" alt="ContactEdit_before" src="https://user-images.githubusercontent.com/46035805/151413103-29acb4df-c7a2-4f36-a5c1-430a989e3091.png">
After:
<img width="1280" alt="ContactEdit_after_new" src="https://user-images.githubusercontent.com/46035805/152640595-3aefeb5a-4901-49f1-91be-5dd1f4ee1b60.png">