### PR TITLE
Tweak dark-theme colors in calendar view

### DIFF
--- a/src/Calendars/Calendar.css
+++ b/src/Calendars/Calendar.css
@@ -7,3 +7,11 @@
     margin: 10px 0;
   }
 }
+
+/* tweak some colors for dark theme */
+.theme-dark .rbc-toolbar button:not(:focus):not(:hover):not(.rbc-active) {
+  color: #fff;
+}
+.theme-dark .rbc-now a, .theme-dark .rbc-today a {
+  color: #000;
+}


### PR DESCRIPTION
I use etesync web in its dark theme and saw that some texts in the calendar view were unreadable (like black text on a dark gray button).
I changed the affected text colors to get a better contrast. Hope that I did not mess up colors somewhere else.

screenshots of this change:
before:
![before](https://github.com/etesync/etesync-web/assets/37334661/b7fc186d-0b4e-4e6e-a63b-4869f92baa61)
![weekview_before](https://github.com/etesync/etesync-web/assets/37334661/44f395a4-e740-4920-9037-6bf6aef52a44)

after:
![after](https://github.com/etesync/etesync-web/assets/37334661/921f209a-d58d-4395-9cc2-caf47cd06b63)
![weekview_after](https://github.com/etesync/etesync-web/assets/37334661/14ed7419-0424-4e1e-b2c6-43a993589caa)