### PR TITLE
fix: add OpenSSL legacy provider for Node.js v17+ compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "uuid": "^3.1.0"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "NODE_OPTIONS=\"--openssl-legacy-provider\" react-scripts start",
+    "build": "NODE_OPTIONS=\"--openssl-legacy-provider\" react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx src",
     "eject": "react-scripts eject"


### PR DESCRIPTION
Add `NODE_OPTIONS="--openssl-legacy-provider"` to start and build scripts to resolve OpenSSL digital envelope routines error with newer Node.js versions while maintaining backward compatibility with Node.js v16 and below.